### PR TITLE
シューティングゲーム改: 重力の働く弾と働かない弾を混ぜる

### DIFF
--- a/Chapter8/Chapter8/ShootingLogic.swift
+++ b/Chapter8/Chapter8/ShootingLogic.swift
@@ -67,6 +67,13 @@ class ShootingLogic: ObservableObject {
             let bulletClone = bullet.clone(recursive: true)
             bulletClone.position = position
             bulletClone.physicsMotion?.linearVelocity = velocity
+            // 重力が効くかを乱数で決める
+            let g = Bool.random()
+            bulletClone.physicsBody?.isAffectedByGravity = g
+            // 重力が効くかによって色を変える
+            var material = PhysicallyBasedMaterial()
+            material.baseColor = .init(tint: g ? .green : .red, texture: nil)
+            bulletClone.model?.materials = [material]
             bulletRoot.addChild(bulletClone)
             // アクションのコールバック
             shootAction()


### PR DESCRIPTION
注: このDraft PRは「さらにステップアップ」の説明用です。実際にマージを要求するものではありません。

## 概要

Chapter 8の「シューティングゲーム改」の開発では、まずは弾に重力が働かず部屋の中を浮遊する版を作成し、次に重力を働かせて弾が床に落ちるようにしました。本ステップアップでは、重力の働く弾と働かない弾がランダムで混ざるようにし、空間コンピューティングならではの非現実的な体験を作り出してみます。

## 差分の確認とコードの修正

[Files changedタブ](./2/files)を開いて差分を確認し、アプリを修正してください。

* Chapter 8の完成プロジェクトから出発します。
* 修正箇所は `ShootingLogic.swift` の `shoot` メソッド内です。
  * `+` で始まる行を追加、`-` で始まる行を削除してください。

## 動作確認

修正後、Vision Pro実機またはシミュレータでアプリを実行してください。重力の働く緑の弾と重力の働かない赤い弾とがランダムで発射されます。

うまく動かないなど、答え合わせが必要な人は[このリンク](https://github.com/HoloLabInc/VisionProSwiftSamples/archive/step-up-random-gravity.zip)から本修正適用済みのアーカイブをダウンロードし、`Chapter8` フォルダを参照してください。

## 解説

ソース差分上のコメントを参照してください。